### PR TITLE
prefix/suffix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gittable"
-version = "0.1.0"
+version = "0.2.0"
 description = "Get stuff from Git"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
This pull request updates the version tagging functionality in the `gittable` project, making it more flexible and user-friendly. The most significant change is the addition of support for custom prefixes and suffixes to the version tag, both in the CLI and the core tagging function. The project version is also bumped to reflect these new capabilities.

Versioning and CLI improvements:

* Bumped the project version in `pyproject.toml` from `0.1.0` to `0.2.0` to indicate new features.
* Added `--prefix` and `--suffix` CLI arguments in `src/gittable/tag_version.py` to allow users to customize the version tag format.

Tagging logic enhancements:

* Updated the `tag_version` function signature to accept optional `prefix` and `suffix` arguments, and included them in the returned tag if provided. [[1]](diffhunk://#diff-90dec62826e9ef226ff03d9ddeab01db4db6b78d3d5ebfdbd14d932f6811fad9L155-R158) [[2]](diffhunk://#diff-90dec62826e9ef226ff03d9ddeab01db4db6b78d3d5ebfdbd14d932f6811fad9R167-L184)
* Refactored git command usage to avoid changing the working directory and instead use the `cwd` argument, improving reliability and clarity.